### PR TITLE
Add session level attribution

### DIFF
--- a/includes/common.js
+++ b/includes/common.js
@@ -1,26 +1,26 @@
 // List of standard fields shared across the rest of the project
 
 // From here: https://segment.com/docs/connections/spec/page/
-let PAGE_FIELDS = [
-    "url",
-    "referrer",
-    "title",
-    "name",
-    "search",
-    "path",
-    "context_campaign_content",
-    "context_campaign_medium",
-    "context_campaign_source",
-    "context_campaign_name",
-    "context_campaign_term",
-    "context_campaign_keyword"];
+let PAGE_FIELDS = {
+    url: "url",
+    referrer: "referrer",
+    title: "title",
+    name: "name",
+    search: "search",
+    path: "path",
+    context_campaign_content: "utm_content",
+    context_campaign_medium: "utm_medium",
+    context_campaign_source: "utm_source",
+    context_campaign_name: "utm_campaign",
+    context_campaign_term: "utm_term",
+    context_campaign_keyword: "utm_keyword"};
 
 // From here: https://segment.com/docs/connections/spec/track/
-let TRACK_FIELDS = [
-  "event"
-];
+let TRACK_FIELDS = {
+  event: "event"
+};
 
 module.exports = {
   PAGE_FIELDS,
-  TRACK_FIELDS
+  TRACK_FIELDS,
 }

--- a/includes/page_events.js
+++ b/includes/page_events.js
@@ -2,11 +2,11 @@ const segmentCommon = require("./common");
 
 module.exports = (params) => {
 
-  const CUSTOM_PAGE_FIELDS_OBJ = {};
-  params.customPageFields.forEach(item => CUSTOM_PAGE_FIELDS_OBJ[item] = item);
+  
 
-  const CUSTOM_TRACK_FIELDS_OBJ = {};
-  params.customTrackFields.forEach(item => CUSTOM_PAGE_FIELDS_OBJ[item] = item);
+  const customPageFieldsObj = params.customPageFields.reduce((acc, item) => ({...acc, [item]: item }), {});
+
+  const customTrackFieldsObj = params.customTrackFields.reduce((acc, item) => ({...acc, [item]: item }), {});
 
   return publish("segment_page_events", {
     ...params.defaultConfig
@@ -22,12 +22,12 @@ select
   context_page_path as path,
   struct(
     cast(null as string) as track_id, 
-    ${Object.entries({...segmentCommon.TRACK_FIELDS, ...segmentCommon.CUSTOM_TRACK_FIELDS_OBJ}).map(
+    ${Object.entries({...segmentCommon.TRACK_FIELDS, ...segmentCommon.customTrackFieldsObj}).map(
             ([key, value]) => `cast(null as string) as ${value}`).join(",\n    ")}
   ) as tracks_info,
   struct(
     id as page_id,
-    ${Object.entries({...segmentCommon.PAGE_FIELDS, ...segmentCommon.CUSTOM_PAGE_FIELDS_OBJ}).map(
+    ${Object.entries({...segmentCommon.PAGE_FIELDS, ...segmentCommon.customPageFieldsObj}).map(
         ([key, value]) => `${key} as ${value}`).join(",\n    ")}
   ) as pages_info
 from

--- a/includes/page_events.js
+++ b/includes/page_events.js
@@ -1,6 +1,13 @@
 const segmentCommon = require("./common");
 
 module.exports = (params) => {
+
+  const CUSTOM_PAGE_FIELDS_OBJ = {};
+  params.customPageFields.forEach(item => CUSTOM_PAGE_FIELDS_OBJ[item] = item);
+
+  const CUSTOM_TRACK_FIELDS_OBJ = {};
+  params.customTrackFields.forEach(item => CUSTOM_PAGE_FIELDS_OBJ[item] = item);
+
   return publish("segment_page_events", {
     ...params.defaultConfig
   }).query(ctx => `
@@ -10,16 +17,18 @@ select
   timestamp,
   user_id,
   anonymous_id,
-  context_ip,
-  context_page_url,
-  context_page_path,
+  context_ip as ip,
+  context_page_url as url,
+  context_page_path as path,
   struct(
     cast(null as string) as track_id, 
-    cast(null as string) as ${[...segmentCommon.TRACK_FIELDS, ...params.customTrackFields].join(",\n cast(null as string) as ")}
+    ${Object.entries({...segmentCommon.TRACK_FIELDS, ...segmentCommon.CUSTOM_TRACK_FIELDS_OBJ}).map(
+            ([key, value]) => `cast(null as string) as ${value}`).join(",\n    ")}
   ) as tracks_info,
   struct(
-      id as page_id,
-      ${[...segmentCommon.PAGE_FIELDS, ...params.customPageFields].join(",\n")}
+    id as page_id,
+    ${Object.entries({...segmentCommon.PAGE_FIELDS, ...segmentCommon.CUSTOM_PAGE_FIELDS_OBJ}).map(
+        ([key, value]) => `${key} as ${value}`).join(",\n    ")}
   ) as pages_info
 from
   ${ctx.ref(params.segmentSchema, "pages")}

--- a/includes/sessionized_events.js
+++ b/includes/sessionized_events.js
@@ -19,9 +19,9 @@ select
     segment_user_anonymous_map.user_id,
     segment_events_combined.anonymous_id
   ) as user_id,
-  context_ip,
-  context_page_url,
-  context_page_path,
+  ip,
+  url,
+  path,
   tracks_info,
   pages_info
 from

--- a/includes/sessions.js
+++ b/includes/sessions.js
@@ -18,6 +18,13 @@ select
   max(timestamp) as session_end_timestamp,
   any_value(ip) as ip,
   any_value(user_id) as user_id,
+  any_value(first_utm_source) as first_utm_source,
+  any_value(first_utm_content) as first_utm_content,
+  any_value(first_utm_medium) as first_utm_medium,
+  any_value(first_utm_campaign) as first_utm_campaign,
+  any_value(first_utm_term) as first_utm_term,
+  any_value(first_utm_keyword) as first_utm_keyword,
+  any_value(first_page_visited) as first_page_visited,
   struct(
     count(tracks_info.track_id) as total_tracks,
     count(pages_info.page_id) as total_pages,
@@ -36,6 +43,5 @@ from
   ${ctx.ref(params.defaultConfig.schema, "segment_sessionized_events")}
 group by
   session_id, session_index
-
 `)
 }

--- a/includes/sessions.js
+++ b/includes/sessions.js
@@ -16,7 +16,7 @@ select
   session_index,
   min(timestamp) as session_start_timestamp,
   max(timestamp) as session_end_timestamp,
-  any_value(context_ip) as context_ip,
+  any_value(ip) as ip,
   any_value(user_id) as user_id,
   struct(
     count(tracks_info.track_id) as total_tracks,
@@ -26,8 +26,8 @@ select
   array_agg(
     struct(
       timestamp,
-      context_page_url,
-      context_page_path,
+      url,
+      path,
       tracks_info as track,
       pages_info as page
     )

--- a/includes/track_events.js
+++ b/includes/track_events.js
@@ -2,11 +2,9 @@ const segmentCommon = require("./common");
 
 module.exports = (params) => {
 
-  const CUSTOM_PAGE_FIELDS_OBJ = {};
-  params.customPageFields.forEach(item => CUSTOM_PAGE_FIELDS_OBJ[item] = item);
+  const customPageFieldsObj = params.customPageFields.reduce((acc, item) => ({...acc, [item]: item }), {});
 
-  const CUSTOM_TRACK_FIELDS_OBJ = {};
-  params.customTrackFields.forEach(item => CUSTOM_PAGE_FIELDS_OBJ[item] = item);
+  const customTrackFieldsObj = params.customTrackFields.reduce((acc, item) => ({...acc, [item]: item }), {});
   
   return publish("segment_track_events", {
     ...params.defaultConfig
@@ -22,12 +20,12 @@ select
   context_page_path as path,
   struct(
     id as track_id,
-    ${Object.entries({...segmentCommon.TRACK_FIELDS, ...segmentCommon.CUSTOM_TRACK_FIELDS_OBJ}).map(
+    ${Object.entries({...segmentCommon.TRACK_FIELDS, ...segmentCommon.customTrackFieldsObj}).map(
         ([key, value]) => `${key} as ${value}`).join(",\n    ")}
       ) as tracks_info,
   struct(
     cast(null as string) as page_id,
-    ${Object.entries({...segmentCommon.PAGE_FIELDS, ...segmentCommon.CUSTOM_PAGE_FIELDS_OBJ}).map(
+    ${Object.entries({...segmentCommon.PAGE_FIELDS, ...segmentCommon.customPageFieldsObj}).map(
         ([key, value]) => `cast(null as string) as ${value}`).join(",\n    ")}
   ) as pages_info
 from

--- a/includes/track_events.js
+++ b/includes/track_events.js
@@ -1,6 +1,13 @@
 const segmentCommon = require("./common");
 
 module.exports = (params) => {
+
+  const CUSTOM_PAGE_FIELDS_OBJ = {};
+  params.customPageFields.forEach(item => CUSTOM_PAGE_FIELDS_OBJ[item] = item);
+
+  const CUSTOM_TRACK_FIELDS_OBJ = {};
+  params.customTrackFields.forEach(item => CUSTOM_PAGE_FIELDS_OBJ[item] = item);
+  
   return publish("segment_track_events", {
     ...params.defaultConfig
   }).query(ctx => `
@@ -10,19 +17,20 @@ select
   timestamp,
   user_id,
   anonymous_id,
-  context_ip,
-  context_page_url,
-  context_page_path,
+  context_ip as ip,
+  context_page_url as url,
+  context_page_path as path,
   struct(
     id as track_id,
-    ${[...segmentCommon.TRACK_FIELDS, ...params.customTrackFields].join(",\n")}
-  ) as tracks_info,
+    ${Object.entries({...segmentCommon.TRACK_FIELDS, ...segmentCommon.CUSTOM_TRACK_FIELDS_OBJ}).map(
+        ([key, value]) => `${key} as ${value}`).join(",\n    ")}
+      ) as tracks_info,
   struct(
     cast(null as string) as page_id,
-    cast(null as string) as ${[...segmentCommon.PAGE_FIELDS, ...params.customPageFields].join(",\n cast(null as string) as ")}
+    ${Object.entries({...segmentCommon.PAGE_FIELDS, ...segmentCommon.CUSTOM_PAGE_FIELDS_OBJ}).map(
+        ([key, value]) => `cast(null as string) as ${value}`).join(",\n    ")}
   ) as pages_info
 from
   ${ctx.ref(params.segmentSchema, "tracks")}
-
 `)
 }


### PR DESCRIPTION
- Rename some fields to something more sensible (e.g. context_campaign_content -> utm_content)
- add some first_ fields to the sessions table (e.g. first_utm_content). It's the first non-null value for utm_content seen in the session. Useful for marketing attribution