### PR TITLE
add support for redshift, postgres

### DIFF
--- a/includes/common.js
+++ b/includes/common.js
@@ -22,5 +22,5 @@ let TRACK_FIELDS = {
 
 module.exports = {
   PAGE_FIELDS,
-  TRACK_FIELDS,
+  TRACK_FIELDS
 }

--- a/includes/crossdb.js
+++ b/includes/crossdb.js
@@ -1,0 +1,34 @@
+function typeString(warehouse) {
+  return ({
+    bigquery: "string",
+    redshift: "varchar",
+    postgres: "varchar",
+    snowflake: "varchar",
+    sqldatawarehouse: "string",
+  })[warehouse || session.config.warehouse];
+}
+
+function timestampDiff(date_part, start_timestamp, end_timestamp, warehouse) {
+  return ({
+    bigquery: `timestamp_diff(${end_timestamp}, ${start_timestamp}, ${date_part})`,
+    redshift: `datediff(${date_part}, ${start_timestamp}, ${end_timestamp})`,
+    postgres: `datediff(${date_part}, ${start_timestamp}, ${end_timestamp})`,
+    snowflake: `datediff(${date_part}, ${start_timestamp}, ${end_timestamp})`,
+    sqldatawarehouse: `datediff(${date_part}, ${start_timestamp}, ${end_timestamp})`
+  })[warehouse || session.config.warehouse];
+}
+
+function generateSurrogateKey(id_array, warehouse) {
+  return ({
+    bigquery: `cast(farm_fingerprint(concat(${id_array.map((id) => (`cast(${id} as ${typeString()})`)).join(`,`)})) as ${typeString()})`,
+    redshift: `md5(concat(${id_array.map((id) => (`cast(${id} as ${typeString()})`)).join(`,`)}))`,
+    postgres: `md5(concat(${id_array.map((id) => (`cast(${id} as ${typeString()})`)).join(`,`)}))`,
+    snowflake: `md5(concat(${id_array.map((id) => (`cast(${id} as ${typeString()})`)).join(`,`)}))`,
+    sqldatawarehouse: `hashbytes("md5", (concat(${id_array.map((id) => (`cast(${id} as ${typeString()})`)).join(`,`)})))`,
+  })[warehouse || session.config.warehouse];
+}
+
+module.exports = {
+  timestampDiff,
+  generateSurrogateKey
+}

--- a/includes/page_events.js
+++ b/includes/page_events.js
@@ -14,22 +14,12 @@ module.exports = (params) => {
 
 -- format page calls into a format suitable to join with track calls
 select
-  timestamp,
+  "timestamp",
   user_id,
   anonymous_id,
-  context_ip as ip,
-  context_page_url as url,
-  context_page_path as path,
-  struct(
-    cast(null as string) as track_id, 
-    ${Object.entries({...segmentCommon.TRACK_FIELDS, ...segmentCommon.customTrackFieldsObj}).map(
-            ([key, value]) => `cast(null as string) as ${value}`).join(",\n    ")}
-  ) as tracks_info,
-  struct(
-    id as page_id,
-    ${Object.entries({...segmentCommon.PAGE_FIELDS, ...segmentCommon.customPageFieldsObj}).map(
-        ([key, value]) => `${key} as ${value}`).join(",\n    ")}
-  ) as pages_info
+  id as page_id,
+  ${Object.entries({...segmentCommon.PAGE_FIELDS, ...segmentCommon.customPageFieldsObj}).map(
+      ([key, value]) => `${key} as ${value}`).join(",\n    ")}
 from
   ${ctx.ref(params.segmentSchema, "pages")}
 

--- a/includes/sessionized_events.js
+++ b/includes/sessionized_events.js
@@ -5,25 +5,36 @@ module.exports = (params) => {
 
 with segment_events_combined as (
 -- combine page and track tables into a full events table
-select * from ${params.segmentSchema, ctx.ref("segment_track_events")}
+select
+  "timestamp",
+  user_id,
+  anonymous_id,
+  track_id,
+  null as page_id
+from 
+  ${params.segmentSchema, ctx.ref("segment_track_events")}
 union all
-select * from ${params.segmentSchema, ctx.ref("segment_page_events")}
+select
+  "timestamp",
+  user_id,
+  anonymous_id,
+  null as track_id,
+  page_id
+from 
+  ${params.segmentSchema, ctx.ref("segment_page_events")}
 ),
 
 segment_events_mapped as (
 -- map anonymous_id to user_id (where possible)
 select
-  timestamp,
+  "timestamp",
   coalesce(
     segment_events_combined.user_id,
     segment_user_anonymous_map.user_id,
     segment_events_combined.anonymous_id
   ) as user_id,
-  ip,
-  url,
-  path,
-  tracks_info,
-  pages_info
+  track_id,
+  page_id
 from
   segment_events_combined
   left join ${ctx.ref(params.defaultConfig.schema, "segment_user_map")} as segment_user_anonymous_map
@@ -36,13 +47,9 @@ select
   *,
   coalesce(
     (
-      unix_millis(timestamp) - unix_millis(
-        lag(timestamp) over (
-          partition by user_id
-          order by
-            timestamp asc
-        )
-      )
+      ${crossdb.timestampDiff(`millisecond`, `"timestamp"`,
+      `lag(timestamp) over (partition by user_id order by timestamp asc)`
+      )}
     ) >= ${params.sessionTimeoutMillis},
     true
   ) as session_start_event
@@ -54,43 +61,22 @@ with_session_index as (
 -- add a session_index (users first session = 1, users second session = 2 etc)
 select
   *,
-  sum(if (session_start_event, 1, 0)) over (
+  sum(case when session_start_event then 1 else 0 end) over (
     partition by user_id
     order by
       timestamp asc
+      rows between unbounded preceding and current row
   ) as session_index
 from
   session_starts
-),
-
--- add a unique session_id to each session
-with_session_id as (
-select
-  *,
-  farm_fingerprint(
-    concat(
-      cast(session_index as string),
-      "|",
-      cast(user_id as string)
-    )
-  ) as session_id
-from
-  with_session_index
 )
 
--- add sessions first utm values
+-- add a unique session_id to each session
 select
   *,
-  -- If we don't have a utm_source, use referrer instead as these are somewhat similar.
-  first_value(coalesce(pages_info.utm_source, pages_info.referrer) ignore nulls) over (partition by session_id order by timestamp asc) as first_utm_source,
-  first_value(pages_info.utm_content ignore nulls) over (partition by session_id order by timestamp asc) as first_utm_content,
-  first_value(pages_info.utm_medium ignore nulls) over (partition by session_id order by timestamp asc) as first_utm_medium,
-  first_value(pages_info.utm_campaign ignore nulls) over (partition by session_id order by timestamp asc) as first_utm_campaign,
-  first_value(pages_info.utm_term ignore nulls) over (partition by session_id order by timestamp asc) as first_utm_term,
-  first_value(pages_info.utm_keyword ignore nulls) over (partition by session_id order by timestamp asc) as first_utm_keyword,
-  first_value(pages_info.path ignore nulls) over (partition by session_id order by timestamp asc) as first_page_visited
-  from
-    with_session_id
+  ${crossdb.generateSurrogateKey(["session_index", "user_id"])} as session_id
+from
+  with_session_index
 
 `)
 }

--- a/includes/sessionized_pages.js
+++ b/includes/sessionized_pages.js
@@ -1,0 +1,25 @@
+const segmentCommon = require("./common");
+
+module.exports = (params) => {
+  return publish("segment_sessionized_pages", {
+    ...params.defaultConfig
+  }).query(ctx => `
+
+-- annotate track records with session details
+select
+  segment_sessionized_events."timestamp",
+  segment_sessionized_events.user_id,
+  segment_sessionized_events.page_id,
+  segment_sessionized_events.session_index,
+  segment_sessionized_events.session_id,
+  ${Object.entries({...segmentCommon.PAGE_FIELDS, ...segmentCommon.customPageFieldsObj}).map(
+      ([key, value]) => `segment_page_events.${value}`).join(",\n  ")}
+from 
+  ${params.segmentSchema, ctx.ref("segment_sessionized_events")} as segment_sessionized_events
+  left join ${params.segmentSchema, ctx.ref("segment_page_events")} as segment_page_events
+    on segment_sessionized_events.page_id = segment_page_events.page_id
+where
+  segment_sessionized_events.page_id is not null
+
+`)
+}

--- a/includes/sessionized_tracks.js
+++ b/includes/sessionized_tracks.js
@@ -1,0 +1,25 @@
+const segmentCommon = require("./common");
+
+module.exports = (params) => {
+  return publish("segment_sessionized_tracks", {
+    ...params.defaultConfig
+  }).query(ctx => `
+
+-- annotate track records with session details
+select
+  segment_sessionized_events."timestamp",
+  segment_sessionized_events.user_id,
+  segment_sessionized_events.track_id,
+  segment_sessionized_events.session_index,
+  segment_sessionized_events.session_id,
+  ${Object.entries({...segmentCommon.TRACK_FIELDS, ...segmentCommon.customTrackFieldsObj}).map(
+      ([key, value]) => `segment_track_events.${value}`).join(",\n  ")}
+from 
+  ${params.segmentSchema, ctx.ref("segment_sessionized_events")} as segment_sessionized_events
+  left join ${params.segmentSchema, ctx.ref("segment_track_events")} as segment_track_events
+    on segment_sessionized_events.track_id = segment_track_events.track_id
+where
+  segment_sessionized_events.track_id is not null
+
+`)
+}

--- a/includes/sessions.js
+++ b/includes/sessions.js
@@ -1,3 +1,5 @@
+const segmentCommon = require("./common");
+
 module.exports = (params) => {
   return publish("segment_sessions", {
     description: "Sessions contain a combined view of tracks and pages from segment. Each session is a period of sustained activity, with a new session starting after a 30min+ period of inactivity. Each session contains a repeated field of records which are either tracks or pages. Common fields are extracted out into the top level and type specific fields are kept within two structs: records.track and records.page",
@@ -5,43 +7,79 @@ module.exports = (params) => {
       session_id: "Unique identifier of the session",
       session_index: "A session counter for each user. session_index=1 is the first session for that users",
       session_start_timestamp: "Timestamp of the first event in the session",
-      session_end_timestamp: "Timestamp of the last event in the session",
-      context_ip: "The IP address the session came from"
+      session_end_timestamp: "Timestamp of the last event in the session"
     },
     ...params.defaultConfig
   }).query(ctx => `
 
+with first_and_last_page_values as (
+select distinct
+  session_id,
+  ${Object.entries({...segmentCommon.PAGE_FIELDS, ...segmentCommon.customPageFieldsObj}).map(
+      ([key, value]) => `first_value(${value} ignore nulls) over (partition by session_id order by "timestamp" asc rows between unbounded preceding and unbounded following) as first_${value}`).join(",\n  ")},
+  ${Object.entries({...segmentCommon.PAGE_FIELDS, ...segmentCommon.customPageFieldsObj}).map(
+      ([key, value]) => `last_value(${value} ignore nulls) over (partition by session_id order by "timestamp" asc rows between unbounded preceding and unbounded following) as last_${value}`).join(",\n  ")}
+  from
+    ${ctx.ref(params.defaultConfig.schema, "segment_sessionized_pages")}
+  )
+
 select
   session_id,
   session_index,
-  min(timestamp) as session_start_timestamp,
-  max(timestamp) as session_end_timestamp,
-  any_value(ip) as ip,
-  any_value(user_id) as user_id,
-  any_value(first_utm_source) as first_utm_source,
-  any_value(first_utm_content) as first_utm_content,
-  any_value(first_utm_medium) as first_utm_medium,
-  any_value(first_utm_campaign) as first_utm_campaign,
-  any_value(first_utm_term) as first_utm_term,
-  any_value(first_utm_keyword) as first_utm_keyword,
-  any_value(first_page_visited) as first_page_visited,
-  struct(
-    count(tracks_info.track_id) as total_tracks,
-    count(pages_info.page_id) as total_pages,
-    timestamp_diff(max(timestamp), min(timestamp), millisecond) as duration_millis
-  ) as stats,
-  array_agg(
+  user_id,
+  min(segment_sessionized_events.timestamp) as session_start_timestamp,
+  max(segment_sessionized_events.timestamp) as session_end_timestamp,
+  
+  -- stats about the session
+  ${ctx.when(global.session.config.warehouse == "bigquery", `struct(\n  `)}
+  count(segment_sessionized_events.track_id) as total_tracks,
+  count(segment_sessionized_events.page_id) as total_pages,
+  ${crossdb.timestampDiff("millisecond", "min(segment_sessionized_events.timestamp)", "max(segment_sessionized_events.timestamp)")}
+  ${ctx.when(global.session.config.warehouse == "bigquery", `) as stats`)},
+
+  -- first values in the session for page fields
+  ${ctx.when(global.session.config.warehouse == "bigquery", `struct(\n  `)}
+  ${Object.entries({...segmentCommon.PAGE_FIELDS, ...segmentCommon.customPageFieldsObj}).map(
+      ([key, value]) => `first_and_last_page_values.first_${value}`).join(",\n  ")}
+  ${ctx.when(global.session.config.warehouse == "bigquery", `) as first_page_values`)},
+
+  -- last values in the session for page fields
+  ${ctx.when(global.session.config.warehouse == "bigquery", `struct(\n  `)}
+  ${Object.entries({...segmentCommon.PAGE_FIELDS, ...segmentCommon.customPageFieldsObj}).map(
+      ([key, value]) => `first_and_last_page_values.last_${value}`).join(",\n  ")}
+  ${ctx.when(global.session.config.warehouse == "bigquery", `) as last_page_values`)}
+  
+  ${ctx.when(global.session.config.warehouse == "bigquery", `-- repeated array of records
+  ,array_agg(
     struct(
-      timestamp,
-      url,
-      path,
-      tracks_info as track,
-      pages_info as page
-    )
-  ) as records
+      segment_sessionized_events."timestamp",
+      struct(
+        segment_sessionized_tracks."timestamp",
+        segment_sessionized_tracks.track_id,
+        ${Object.entries({...segmentCommon.TRACK_FIELDS, ...segmentCommon.customTrackFieldsObj}).map(
+      ([key, value]) => `segment_sessionized_tracks.${value}`).join(",\n  ")}
+      ) as track,
+      struct(
+        segment_sessionized_pages."timestamp",
+        segment_sessionized_pages.page_id,
+        ${Object.entries({...segmentCommon.PAGE_FIELDS, ...segmentCommon.customPageFieldsObj}).map(
+      ([key, value]) => `segment_sessionized_pages.${value}`).join(",\n  ")}
+      ) as page
+    ) order by segment_sessionized_events."timestamp" asc
+  ) as records`)}
 from
   ${ctx.ref(params.defaultConfig.schema, "segment_sessionized_events")}
+  left join first_and_last_page_values
+    using(session_id)
+  ${ctx.when(global.session.config.warehouse == "bigquery", `
+  left join ${ctx.ref(params.defaultConfig.schema, "segment_sessionized_pages")} as segment_sessionized_pages
+    using(page_id)
+  left join ${ctx.ref(params.defaultConfig.schema, "segment_sessionized_tracks")} as segment_sessionized_tracks
+    using(track_id)`)}
 group by
-  session_id, session_index
+  session_id, session_index, user_id ${Object.entries({...segmentCommon.PAGE_FIELDS, ...segmentCommon.customPageFieldsObj}).map(
+      ([key, value]) => `, first_${value}`).join(" ")}
+  ${Object.entries({...segmentCommon.PAGE_FIELDS, ...segmentCommon.customPageFieldsObj}).map(
+      ([key, value]) => `, last_${value}`).join(" ")}
 `)
 }

--- a/includes/track_events.js
+++ b/includes/track_events.js
@@ -12,22 +12,12 @@ module.exports = (params) => {
 
 -- format track calls into a format suitable to join with page calls
 select
-  timestamp,
+  "timestamp",
   user_id,
   anonymous_id,
-  context_ip as ip,
-  context_page_url as url,
-  context_page_path as path,
-  struct(
-    id as track_id,
-    ${Object.entries({...segmentCommon.TRACK_FIELDS, ...segmentCommon.customTrackFieldsObj}).map(
-        ([key, value]) => `${key} as ${value}`).join(",\n    ")}
-      ) as tracks_info,
-  struct(
-    cast(null as string) as page_id,
-    ${Object.entries({...segmentCommon.PAGE_FIELDS, ...segmentCommon.customPageFieldsObj}).map(
-        ([key, value]) => `cast(null as string) as ${value}`).join(",\n    ")}
-  ) as pages_info
+  id as track_id,
+  ${Object.entries({...segmentCommon.TRACK_FIELDS, ...segmentCommon.customTrackFieldsObj}).map(
+      ([key, value]) => `${key} as ${value}`).join(",\n    ")}
 from
   ${ctx.ref(params.segmentSchema, "tracks")}
 `)

--- a/includes/users.js
+++ b/includes/users.js
@@ -1,3 +1,9 @@
+let USER = `coalesce(
+  identifies.user_id,
+  segment_user_anonymous_map.user_id,
+  segment_user_anonymous_map.anonymous_id
+)`;
+
 module.exports = (params) => {
   return publish("segment_users", {
     description: "Users aggregates all identifies calls to give a table with one row per user_id. Identify calls without only an anonymous_id are mapped to the user where possible.",
@@ -8,20 +14,14 @@ module.exports = (params) => {
     ...params.defaultConfig
   }).query(ctx => `
 
-select
-    coalesce(
-    identifies.user_id,
-    segment_user_anonymous_map.user_id,
-    segment_user_anonymous_map.anonymous_id
-  ) as user_id,
-  min(timestamp) AS first_seen_at,
-  ${params.customUserFields.map(f=>`array_agg(${f} ignore nulls order by timestamp desc)[safe_offset(0)] as ${f}`).join(",\n  ")}
+select distinct
+  ${USER} as user_id,
+  first_value(timestamp ignore nulls) over (partition by ${USER} order by timestamp asc rows between unbounded preceding and unbounded following) as timestamp,
+  ${params.customUserFields.map(f=>`first_value(${f} ignore nulls) over (partition by ${USER} order by timestamp desc rows between unbounded preceding and unbounded following) as ${f}`).join(",\n  ")}
 from
   ${ctx.ref(params.defaultConfig.schema, "segment_user_map")} as segment_user_anonymous_map
   left join ${ctx.ref(params.segmentSchema, "identifies")} as identifies
     on identifies.anonymous_id = segment_user_anonymous_map.anonymous_id
-group by
-  user_id
 
 `)
 }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,9 @@ const users = require("./includes/users");
 const sessionizedEvents = require("./includes/sessionized_events");
 const sessions = require("./includes/sessions");
 const pageEvents = require("./includes/page_events");
+const sessionizedPages = require("./includes/sessionized_pages");
 const trackEvents = require("./includes/track_events");
+const sessionizedTracks = require("./includes/sessionized_tracks");
 const userMap = require("./includes/user_map");
 
 module.exports = (params) => {
@@ -49,7 +51,9 @@ module.exports = (params) => {
     sessionizedEvents: sessionizedEvents(params),
     sessions: sessions(params),
     pageEvents: pageEvents(params),
+    sessionizedPages: sessionizedPages(params),
     trackEvents: trackEvents(params),
+    sessionizedTracks: sessionizedTracks(params),
     userMap: userMap(params),
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,29 +3,29 @@
     "lockfileVersion": 1,
     "dependencies": {
         "@dataform/core": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/@dataform/core/-/core-1.4.5.tgz",
-            "integrity": "sha512-ik7cbYIrCNLJg1xzBklG4PGct8G5hUzfGTxsRTpykSKjXSu1TRclX4w6JZAE9JeqU5C7UC+rDXOEhcrluvW1dQ==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@dataform/core/-/core-1.5.0.tgz",
+            "integrity": "sha512-i61hyJQfsTB6IZx17Ab/WPXKLrM83VEjVt5uErK8YdIE8UDXsJOHCkICWx6DpgWSuBm8ZKL6B0+Bk3PbBsAKUQ==",
             "requires": {
-                "@dataform/protos": "1.4.5",
-                "@dataform/sqlx": "1.4.5",
+                "@dataform/protos": "1.5.0",
+                "@dataform/sqlx": "1.5.0",
                 "protobufjs": "^6.8.8",
                 "semver": "^5.6.0",
                 "tarjan-graph": "^2.0.0"
             }
         },
         "@dataform/protos": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/@dataform/protos/-/protos-1.4.5.tgz",
-            "integrity": "sha512-s+AwYrHK5Nh4QOZAYRKxhspiY4RWIR9jh6CVSNhERfqfV/j2N9x7p5XDa3mld547O2VKxttnTxHEfXMVsYFC7g==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@dataform/protos/-/protos-1.5.0.tgz",
+            "integrity": "sha512-oZOAnrhOJIaxMv/iIpB18MXMON9QE8JkiigxhEctMbbU077i85bpihBcq3NePsmTD7J9J2hvalJuN235QUEQVA==",
             "requires": {
                 "protobufjs": "^6.8.8"
             }
         },
         "@dataform/sqlx": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/@dataform/sqlx/-/sqlx-1.4.5.tgz",
-            "integrity": "sha512-kAsyHPjyt40Iq1EEumJhLsAsE3115TXNwvSdGHhae7KeucN/X2xXDfmOMgXs6ryG/jDiKxdIHESyprg9owUCjA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@dataform/sqlx/-/sqlx-1.5.0.tgz",
+            "integrity": "sha512-vVHT/cNQIobJpeAJY6IafH+5Nx2ndCyHv92g6eeVLY8Oc1jjp/OMgxhhNZQozxHy/v/AMTZTqBlC0oxlyea+/g==",
             "requires": {
                 "moo": "^0.5.0"
             }
@@ -85,14 +85,14 @@
             "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
         },
         "@types/long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+            "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
         },
         "@types/node": {
-            "version": "10.17.11",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.11.tgz",
-            "integrity": "sha512-dNd2pp8qTzzNLAs3O8nH3iU9DG9866KHq9L3ISPB7DOGERZN81nW/5/g/KzMJpCU8jrbCiMRBzV9/sCEdRosig=="
+            "version": "10.17.17",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
+            "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
         },
         "long": {
             "version": "4.0.0",
@@ -105,9 +105,9 @@
             "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
         },
         "protobufjs": {
-            "version": "6.8.8",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
-            "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+            "version": "6.8.9",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.9.tgz",
+            "integrity": "sha512-j2JlRdUeL/f4Z6x4aU4gj9I2LECglC+5qR2TrWb193Tla1qfdaNQTZ8I27Pt7K0Ajmvjjpft7O3KWTGciz4gpw==",
             "requires": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
     "dependencies": {
-        "@dataform/core": "1.4.5"
+        "@dataform/core": "1.5.0"
     }
 }


### PR DESCRIPTION
- add a couple of crossdb functions (we should move these into a separate package as soon as we have another package to reference them in!)
- make several tweaks to the SQL such that it works in both postgres/redshift and bigquery
- create sessionized_tracks and sessionized_pages datasets (these are essentially replacements to the repeated struct format for BigQuery
- Remove web specific fields from the sessions table, leaving them in pages/tracks (in the future we should support app-only analytics)
- add first_ and last_ fields for page fields to the sessions table. These are useful for attribution analytics (and also for quick filtering of sessions)